### PR TITLE
refine early chain lift reward and curriculum start length

### DIFF
--- a/openrct2_gym/envs/openrct2_env.py
+++ b/openrct2_gym/envs/openrct2_env.py
@@ -270,16 +270,17 @@ class OpenRCT2Env(gym.Env):
             # Base reward for successful action
             reward += 1
 
-            # FIX: Reward for placing chain lifts in the beginning (actions 9 and 10)
-            # But prevent exploitation by tracking positions
-            if self.track_length < 30 and self.last_action in [9, 10]:
+            # Reward for placing chain lifts early (actions 9 and 10), but at a
+            # reduced incentive so the agent still has pieces left to return to
+            # the station. Limit the reward to the first 15 pieces to avoid
+            # spending the entire budget on hills.
+            if self.track_length < 15 and self.last_action in [9, 10]:
                 position_key = tuple(self.current_position)
                 # Only reward if this is a NEW position for chain lift
-                if position_key not in self.chain_lift_positions:
-                    if self.chain_lift_count < self.max_chain_lifts:
-                        reward += 10  # Increased from 5
-                        self.chain_lift_count += 1
-                        self.chain_lift_positions.add(position_key)
+                if position_key not in self.chain_lift_positions and self.chain_lift_count < self.max_chain_lifts:
+                    reward += 5  # smaller bonus than before
+                    self.chain_lift_count += 1
+                    self.chain_lift_positions.add(position_key)
                 else:
                     # Penalty for rebuilding chain lift in same position
                     reward -= 3

--- a/train_curriculum_masked.py
+++ b/train_curriculum_masked.py
@@ -161,8 +161,8 @@ def create_curriculum_masked_env(use_adaptive=False):
     if use_adaptive:
         env = AdaptiveCurriculumWrapper(
             base_env,
-            initial_max_length=30,
-            target_max_length=100,
+            initial_max_length=50,
+            target_max_length=120,
             success_threshold=0.2,  # 20% success to advance
             window_size=50,
             increase_step=10
@@ -170,8 +170,8 @@ def create_curriculum_masked_env(use_adaptive=False):
     else:
         env = CurriculumWrapper(
             base_env,
-            initial_max_length=30,
-            target_max_length=100,
+            initial_max_length=50,
+            target_max_length=120,
             success_threshold=0.2,
             window_size=50,
             increase_step=10


### PR DESCRIPTION
## Summary
- Reduce chain lift reward and limit to first 15 pieces to leave room for return path
- Start curriculum training with 50-piece tracks and expand to 120

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'track_builder')*

------
https://chatgpt.com/codex/tasks/task_e_68ab6300a73083268382ddfb0234839f