### PR TITLE
Isolate curriculum stats during evaluation

### DIFF
--- a/openrct2_gym/envs/curriculum_wrapper.py
+++ b/openrct2_gym/envs/curriculum_wrapper.py
@@ -5,6 +5,7 @@ Gradually increases difficulty as agent improves
 import gymnasium as gym
 import numpy as np
 from collections import deque
+from contextlib import contextmanager
 
 class CurriculumWrapper(gym.Wrapper):
     """
@@ -35,12 +36,16 @@ class CurriculumWrapper(gym.Wrapper):
         self.current_max_length = initial_max_length
         self.success_threshold = success_threshold
         self.increase_step = increase_step
-        
+
         # Performance tracking
         self.episode_results = deque(maxlen=window_size)
         self.episode_count = 0
         self.current_stage = 1
         self.stages_completed = []
+
+        # Flag to control whether statistics should be updated. During
+        # evaluation we can disable this to prevent curriculum progression.
+        self._track_stats = True
         
         # Update environment's max track length
         self._update_difficulty()
@@ -66,13 +71,13 @@ class CurriculumWrapper(gym.Wrapper):
     def reset(self, **kwargs):
         """Reset environment and potentially adjust difficulty"""
         # Check if we should increase difficulty
-        if len(self.episode_results) >= 50:  # Need at least 50 episodes
+        if self._track_stats and len(self.episode_results) >= 50:  # Need at least 50 episodes
             success_rate = sum(self.episode_results) / len(self.episode_results)
-            
+
             # Check if we should advance to next stage
-            if (success_rate >= self.success_threshold and 
+            if (success_rate >= self.success_threshold and
                 self.current_max_length < self.target_max_length):
-                
+
                 # Record completion of current stage
                 self.stages_completed.append({
                     'stage': self.current_stage,
@@ -80,7 +85,7 @@ class CurriculumWrapper(gym.Wrapper):
                     'success_rate': success_rate,
                     'episodes': self.episode_count
                 })
-                
+
                 # Increase difficulty
                 self.current_max_length = min(
                     self.current_max_length + self.increase_step,
@@ -88,10 +93,10 @@ class CurriculumWrapper(gym.Wrapper):
                 )
                 self.current_stage += 1
                 self._update_difficulty()
-                
+
                 # Clear history for new stage
                 self.episode_results.clear()
-                
+
                 # Only print if base environment has verbose >= 1
                 base_env = self._get_base_env()
                 if hasattr(base_env, 'verbose') and base_env.verbose >= 1:
@@ -116,22 +121,22 @@ class CurriculumWrapper(gym.Wrapper):
         obs, reward, terminated, truncated, info = self.env.step(action)
         
         # Track episode completion
-        if terminated or truncated:
+        if terminated or truncated and self._track_stats:
             self.episode_count += 1
-            
+
             # Check if loop was completed
             base_env = self._get_base_env()
             success = base_env.loop_completed if hasattr(base_env, 'loop_completed') else False
             self.episode_results.append(success)
-            
+
             # Add curriculum info to episode info
             info['curriculum_success'] = success
             info['curriculum_stage'] = self.current_stage
             info['curriculum_success_rate'] = (
-                sum(self.episode_results) / len(self.episode_results) 
+                sum(self.episode_results) / len(self.episode_results)
                 if self.episode_results else 0
             )
-            
+
             # Provide curriculum feedback
             if self.episode_count % 10 == 0:
                 base_env = self._get_base_env()
@@ -148,6 +153,16 @@ class CurriculumWrapper(gym.Wrapper):
             reward += 20
         
         return obs, reward, terminated, truncated, info
+
+    @contextmanager
+    def evaluation_mode(self):
+        """Context manager to temporarily disable curriculum statistic updates."""
+        prev = self._track_stats
+        self._track_stats = False
+        try:
+            yield
+        finally:
+            self._track_stats = prev
     
     def get_curriculum_stats(self):
         """Get current curriculum learning statistics"""

--- a/train_curriculum_masked.py
+++ b/train_curriculum_masked.py
@@ -15,6 +15,7 @@ from sb3_contrib.common.maskable.callbacks import MaskableEvalCallback
 from stable_baselines3.common.vec_env import DummyVecEnv
 from stable_baselines3.common.callbacks import CheckpointCallback, BaseCallback
 from stable_baselines3.common.monitor import Monitor
+from contextlib import ExitStack
 import numpy as np
 import os
 import argparse
@@ -142,41 +143,47 @@ def mask_fn(env: gym.Env) -> np.ndarray:
     print("Warning: Could not find valid_action_mask method, allowing all actions")
     return np.ones(env.action_space.n, dtype=bool)
 
-def create_curriculum_masked_env(use_adaptive=False):
-    """Create environment with curriculum wrapper and action masking"""
+def create_curriculum_masked_env(use_adaptive=False, include_curriculum=True):
+    """Create environment with optional curriculum wrapper and action masking"""
     # Base environment
     base_env = gym.make('OpenRCT2-v0')
-    
+
     # Add OpenRCT2Wrapper to expose valid_action_mask method
     # This is crucial for the mask_fn to work
     base_env = OpenRCT2Wrapper(base_env)
-    
-    # Apply curriculum wrapper
-    if use_adaptive:
-        env = AdaptiveCurriculumWrapper(
-            base_env,
-            initial_max_length=50,
-            target_max_length=120,
-            success_threshold=0.2,  # 20% success to advance
-            window_size=50,
-            increase_step=10
-        )
+
+    env = base_env
+
+    # Apply curriculum wrapper only when training
+    if include_curriculum:
+        if use_adaptive:
+            env = AdaptiveCurriculumWrapper(
+                base_env,
+                initial_max_length=50,
+                target_max_length=120,
+                success_threshold=0.2,  # 20% success to advance
+                window_size=50,
+                increase_step=10
+            )
+        else:
+            env = CurriculumWrapper(
+                base_env,
+                initial_max_length=50,
+                target_max_length=120,
+                success_threshold=0.2,
+                window_size=50,
+                increase_step=10
+            )
     else:
-        env = CurriculumWrapper(
-            base_env,
-            initial_max_length=50,
-            target_max_length=120,
-            success_threshold=0.2,
-            window_size=50,
-            increase_step=10
-        )
-    
+        # When evaluating without curriculum, fix track length to target difficulty
+        base_env.max_track_length = 120
+
     # Add Monitor for logging
     env = Monitor(env)
-    
+
     # Add ActionMasker for MaskablePPO
     env = ActionMasker(env, mask_fn)
-    
+
     return env
 
 def train_curriculum_masked(total_timesteps, checkpoint_freq, eval_freq, 
@@ -192,10 +199,11 @@ def train_curriculum_masked(total_timesteps, checkpoint_freq, eval_freq,
     print("="*60 + "\n")
     
     # Create environments
-    env_fn = lambda: create_curriculum_masked_env(use_adaptive)
+    env_fn = lambda: create_curriculum_masked_env(use_adaptive, include_curriculum=True)
     env = DummyVecEnv([env_fn])
-    
-    eval_env_fn = lambda: create_curriculum_masked_env(use_adaptive)
+
+    # Evaluation environment without curriculum to avoid affecting statistics
+    eval_env_fn = lambda: create_curriculum_masked_env(use_adaptive, include_curriculum=False)
     eval_env = DummyVecEnv([eval_env_fn])
     
     # Create or load model
@@ -341,7 +349,19 @@ def main():
     
     # Final evaluation using maskable evaluation
     print("\n📈 Final evaluation with masking...")
-    mean_reward, std_reward = evaluate_policy(model, env, n_eval_episodes=20)
+    # Disable curriculum updates during evaluation
+    with ExitStack() as stack:
+        if hasattr(env, 'envs') and len(env.envs) > 0:
+            temp_env = env.envs[0]
+            while temp_env is not None:
+                if isinstance(temp_env, (CurriculumWrapper, AdaptiveCurriculumWrapper)):
+                    stack.enter_context(temp_env.evaluation_mode())
+                    break
+                if hasattr(temp_env, 'env'):
+                    temp_env = temp_env.env
+                else:
+                    break
+        mean_reward, std_reward = evaluate_policy(model, env, n_eval_episodes=20)
     print(f"Mean reward: {mean_reward:.2f} ± {std_reward:.2f}")
     
     env.close()

--- a/train_parallel_curriculum_masked.py
+++ b/train_parallel_curriculum_masked.py
@@ -20,6 +20,7 @@ import argparse
 import time
 import math
 from typing import List, Callable
+from contextlib import ExitStack
 
 class ParallelCurriculumMaskableCallback(BaseCallback):
     """
@@ -392,7 +393,25 @@ def train_parallel_curriculum_masked(
             # Evaluate between chunks using the training env to avoid port conflicts
             if not disable_eval and eval_episodes > 0:
                 print(f"\n📈 Intermediate evaluation after {learned:,} timesteps...")
-                mean_reward, std_reward = evaluate_policy(model, env, n_eval_episodes=eval_episodes)
+
+                # Temporarily disable curriculum statistics during evaluation
+                curriculum_wrappers = []
+                if hasattr(env, 'envs'):
+                    for wrapped_env in env.envs:
+                        temp_env = wrapped_env
+                        while temp_env is not None:
+                            if isinstance(temp_env, (CurriculumWrapper, AdaptiveCurriculumWrapper)):
+                                curriculum_wrappers.append(temp_env)
+                                break
+                            if hasattr(temp_env, 'env'):
+                                temp_env = temp_env.env
+                            else:
+                                break
+
+                with ExitStack() as stack:
+                    for cw in curriculum_wrappers:
+                        stack.enter_context(cw.evaluation_mode())
+                    mean_reward, std_reward = evaluate_policy(model, env, n_eval_episodes=eval_episodes)
                 print(f"  Mean reward: {mean_reward:.2f} ± {std_reward:.2f}")
         
     except KeyboardInterrupt:


### PR DESCRIPTION
## Summary
- add context manager to CurriculumWrapper to disable statistic updates during eval
- create evaluation env without curriculum wrapper for masked training script
- suppress curriculum progression during parallel and final evaluations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'track_builder')*

------
https://chatgpt.com/codex/tasks/task_e_68b5ceef1ec08326980d709aacb59f11